### PR TITLE
Use double-checked locking in NotificationUtils

### DIFF
--- a/src/com/android/mail/utils/NotificationUtils.java
+++ b/src/com/android/mail/utils/NotificationUtils.java
@@ -95,7 +95,7 @@ public class NotificationUtils {
     public static final String EXTRA_GET_ATTENTION = "get-attention";
 
     /** Contains a list of <(account, label), unread conversations> */
-    private static NotificationMap sActiveNotificationMap = null;
+    private static volatile NotificationMap sActiveNotificationMap = null;
 
     private static final SparseArray<Bitmap> sNotificationIcons = new SparseArray<Bitmap>();
     private static WeakReference<Bitmap> sDefaultWearableBg = new WeakReference<Bitmap>(null);
@@ -131,12 +131,16 @@ public class NotificationUtils {
     /**
      * Returns the notification map, creating it if necessary.
      */
-    private static synchronized NotificationMap getNotificationMap(Context context) {
+    private static NotificationMap getNotificationMap(Context context) {
         if (sActiveNotificationMap == null) {
-            sActiveNotificationMap = new NotificationMap();
-
-            // populate the map from the cached data
-            sActiveNotificationMap.loadNotificationMap(context);
+            synchronized (NotificationUtils.class) {
+                if (sActiveNotificationMap == null) {
+                    sActiveNotificationMap = new NotificationMap();
+                    
+                    // populate the map from the cached data
+                    sActiveNotificationMap.loadNotificationMap(context);
+                }
+            }
         }
         return sActiveNotificationMap;
     }


### PR DESCRIPTION
Use double-checked locking in getNotificationMap method of NotificationUtils.  Once sActiveNotificationMap is assigned, there is no need to synchronize it any more beacause reading it concurrently will not cause concurrency problem.